### PR TITLE
Support tolerations on deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -259,9 +259,14 @@ resource "kubernetes_deployment" "kubernetes_dashboard" {
 
         node_selector = var.kubernetes_deployment_node_selector
 
-        toleration {
-          key = "node-role.kubernetes.io/master"
-          effect = "NoSchedule"
+        dynamic toleration {
+          for_each = var.kubernetes_deployment_tolerations
+          content {
+            key      = toleration.value.key
+            operator = toleration.value.operator
+            value    = toleration.value.value
+            effect   = toleration.value.effect
+          }
         }
       }
     }
@@ -336,9 +341,14 @@ resource "kubernetes_deployment" "kubernetes_metrics_scraper" {
 
         node_selector = var.kubernetes_deployment_node_selector
 
-        toleration {
-          key = "node-role.kubernetes.io/master"
-          effect = "NoSchedule"
+        dynamic toleration {
+          for_each = var.kubernetes_deployment_tolerations
+          content {
+            key      = toleration.value.key
+            operator = toleration.value.operator
+            value    = toleration.value.value
+            effect   = toleration.value.effect
+          }
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,24 @@ variable "kubernetes_deployment_node_selector" {
   description = "Node selectors for kubernetes deployment"
 }
 
+variable "kubernetes_deployment_tolerations" {
+  type = list(object({
+    key = string
+    operator = string
+    value = string
+    effect = string
+  }))
+
+  default = [
+    {
+      key = "node-role.kubernetes.io/master"
+      operator = "Equal"
+      value = ""
+      effect = "NoSchedule"
+    }
+  ]
+}
+
 variable "kubernetes_service_account_name" {
   type = string
   default = "kubernetes-dashboard"


### PR DESCRIPTION
Introduce `kubernetes_deployment_tolerations` variable with a default
value preserving backwards compatibility.

This variable allows to override the default toleration in case the
dashboard is to be deployed on a tainted node.